### PR TITLE
Refactor synchronizer

### DIFF
--- a/src/CocApi.Cache/Clients/ClansClient.cs
+++ b/src/CocApi.Cache/Clients/ClansClient.cs
@@ -96,8 +96,7 @@ public class ClansClient : ClientBase<ClansClient>
 
         CacheDbContext dbContext = scope.ServiceProvider.GetRequiredService<CacheDbContext>();
 
-        while (!Synchronizer.UpdatingClan.TryAdd(formattedTag, null))
-            await Task.Delay(250).ConfigureAwait(false);
+        await Synchronizer.ClanLock.AcquireAsync(formattedTag).ConfigureAwait(false);
 
         try
         {
@@ -110,7 +109,7 @@ public class ClansClient : ClientBase<ClansClient>
         }
         finally
         {
-            Synchronizer.UpdatingClan.TryRemove(formattedTag, out _);
+            Synchronizer.ClanLock.Release(formattedTag);
         }
     }
 

--- a/src/CocApi.Cache/Clients/PlayersClient.cs
+++ b/src/CocApi.Cache/Clients/PlayersClient.cs
@@ -82,8 +82,7 @@ public class PlayersClient : ClientBase<PlayersClient>
 
         CacheDbContext dbContext = scope.ServiceProvider.GetRequiredService<CacheDbContext>();
 
-        while (!Synchronizer.UpdatingVillage.TryAdd(formattedTag, null))
-            await Task.Delay(250).ConfigureAwait(false);
+        await Synchronizer.VillageLock.AcquireAsync(formattedTag).ConfigureAwait(false);
 
         try
         {
@@ -96,7 +95,7 @@ public class PlayersClient : ClientBase<PlayersClient>
         }
         finally
         {
-            Synchronizer.UpdatingVillage.TryRemove(formattedTag, out _);
+            Synchronizer.VillageLock.Release(formattedTag);
         }
     }
 

--- a/src/CocApi.Cache/CocApi.Cache.csproj
+++ b/src/CocApi.Cache/CocApi.Cache.csproj
@@ -6,7 +6,7 @@
     <Authors>devhl</Authors>
     <Product />
     <Description>Caches response from the Clash of Clans API.</Description>
-    <Version>2.14.4</Version>
+    <Version>2.14.5</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/CocApi.Cache/Common/Synchronizer.cs
+++ b/src/CocApi.Cache/Common/Synchronizer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -27,61 +26,5 @@ public sealed class Synchronizer : IDisposable
         VillageLock.Dispose();
         WarLock.Dispose();
         CwlWarLock.Dispose();
-    }
-
-    internal sealed class TagLock : IDisposable
-    {
-        private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
-        private readonly System.Timers.Timer _timer;
-
-        internal TagLock(TimeSpan? cleanupInterval = null)
-        {
-            _timer = new System.Timers.Timer((cleanupInterval ?? TimeSpan.FromMinutes(5)).TotalMilliseconds);
-            _timer.Elapsed += (_, _) => Cleanup();
-            _timer.AutoReset = true;
-            _timer.Start();
-        }
-
-        public bool TryAcquire(string tag)
-        {
-            var semaphore = _semaphores.GetOrAdd(tag, _ => new SemaphoreSlim(1, 1));
-            return semaphore.Wait(0);
-        }
-
-        public Task AcquireAsync(string tag, CancellationToken cancellationToken = default)
-        {
-            var semaphore = _semaphores.GetOrAdd(tag, _ => new SemaphoreSlim(1, 1));
-            return semaphore.WaitAsync(cancellationToken);
-        }
-
-        public void Release(string tag)
-        {
-            if (_semaphores.TryGetValue(tag, out var semaphore))
-                semaphore.Release();
-        }
-
-        private void Cleanup()
-        {
-            foreach (var (tag, semaphore) in _semaphores)
-            {
-                if (!semaphore.Wait(0))
-                    continue;
-
-                // Only remove if this exact instance is still in the dictionary.
-                // If lost the race (another thread replaced it), just release.
-                if (!_semaphores.TryRemove(new KeyValuePair<string, SemaphoreSlim>(tag, semaphore)))
-                    semaphore.Release();
-                // Intentionally not disposing: SemaphoreSlim has no unmanaged resources
-                // unless AvailableWaitHandle is accessed (which we never do).
-            }
-        }
-
-        public void Dispose()
-        {
-            _timer.Dispose();
-            foreach (var semaphore in _semaphores.Values)
-                semaphore.Dispose();
-            _semaphores.Clear();
-        }
     }
 }

--- a/src/CocApi.Cache/Common/Synchronizer.cs
+++ b/src/CocApi.Cache/Common/Synchronizer.cs
@@ -1,23 +1,87 @@
-﻿using System.Collections.Concurrent;
-using CocApi.Cache.Context;
-using CocApi.Rest.Models;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace CocApi.Cache;
 
-public sealed class Synchronizer
+public sealed class Synchronizer : IDisposable
 {
     public static bool Instantiated { get; private set; }
 
-
-    internal ConcurrentDictionary<string, CachedClan?> UpdatingClan { get; } = new();
-    internal ConcurrentDictionary<string, ClanWar?> UpdatingWar { get; } = new();
-    internal ConcurrentDictionary<string, ClanWar?> UpdatingCwlWar { get; } = new();
-    internal ConcurrentDictionary<string, CachedPlayer?> UpdatingVillage { get; set; } = new();
-
+    internal TagLock ClanLock { get; } = new();
+    internal TagLock VillageLock { get; } = new();
+    internal TagLock WarLock { get; } = new();
+    internal TagLock CwlWarLock { get; } = new();
 
     public Synchronizer(ILogger<Synchronizer> logger)
     {
         Instantiated = Library.WarnOnSubsequentInstantiations(logger, Instantiated);
+    }
+
+    public void Dispose()
+    {
+        ClanLock.Dispose();
+        VillageLock.Dispose();
+        WarLock.Dispose();
+        CwlWarLock.Dispose();
+    }
+
+    internal sealed class TagLock : IDisposable
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
+        private readonly System.Timers.Timer _timer;
+
+        internal TagLock(TimeSpan? cleanupInterval = null)
+        {
+            _timer = new System.Timers.Timer((cleanupInterval ?? TimeSpan.FromMinutes(5)).TotalMilliseconds);
+            _timer.Elapsed += (_, _) => Cleanup();
+            _timer.AutoReset = true;
+            _timer.Start();
+        }
+
+        public bool TryAcquire(string tag)
+        {
+            var semaphore = _semaphores.GetOrAdd(tag, _ => new SemaphoreSlim(1, 1));
+            return semaphore.Wait(0);
+        }
+
+        public Task AcquireAsync(string tag, CancellationToken cancellationToken = default)
+        {
+            var semaphore = _semaphores.GetOrAdd(tag, _ => new SemaphoreSlim(1, 1));
+            return semaphore.WaitAsync(cancellationToken);
+        }
+
+        public void Release(string tag)
+        {
+            if (_semaphores.TryGetValue(tag, out var semaphore))
+                semaphore.Release();
+        }
+
+        private void Cleanup()
+        {
+            foreach (var (tag, semaphore) in _semaphores)
+            {
+                if (!semaphore.Wait(0))
+                    continue;
+
+                // Only remove if this exact instance is still in the dictionary.
+                // If lost the race (another thread replaced it), just release.
+                if (!_semaphores.TryRemove(new KeyValuePair<string, SemaphoreSlim>(tag, semaphore)))
+                    semaphore.Release();
+                // Intentionally not disposing: SemaphoreSlim has no unmanaged resources
+                // unless AvailableWaitHandle is accessed (which we never do).
+            }
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+            foreach (var semaphore in _semaphores.Values)
+                semaphore.Dispose();
+            _semaphores.Clear();
+        }
     }
 }

--- a/src/CocApi.Cache/Common/TagLock.cs
+++ b/src/CocApi.Cache/Common/TagLock.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CocApi.Cache;
+
+internal sealed class TagLock : IDisposable
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
+    private readonly System.Timers.Timer _timer;
+
+    internal TagLock(TimeSpan? cleanupInterval = null)
+    {
+        _timer = new System.Timers.Timer((cleanupInterval ?? TimeSpan.FromMinutes(5)).TotalMilliseconds);
+        _timer.Elapsed += (_, _) => Cleanup();
+        _timer.AutoReset = true;
+        _timer.Start();
+    }
+
+    public bool TryAcquire(string tag)
+    {
+        var semaphore = _semaphores.GetOrAdd(tag, _ => new SemaphoreSlim(1, 1));
+        return semaphore.Wait(0);
+    }
+
+    public Task AcquireAsync(string tag, CancellationToken cancellationToken = default)
+    {
+        var semaphore = _semaphores.GetOrAdd(tag, _ => new SemaphoreSlim(1, 1));
+        return semaphore.WaitAsync(cancellationToken);
+    }
+
+    public void Release(string tag)
+    {
+        if (_semaphores.TryGetValue(tag, out var semaphore))
+            semaphore.Release();
+    }
+
+    private void Cleanup()
+    {
+        foreach (var (tag, semaphore) in _semaphores)
+        {
+            if (!semaphore.Wait(0))
+                continue;
+
+            // Only remove if this exact instance is still in the dictionary.
+            // If lost the race (another thread replaced it), just release.
+            if (!_semaphores.TryRemove(new KeyValuePair<string, SemaphoreSlim>(tag, semaphore)))
+                semaphore.Release();
+            // Intentionally not disposing: SemaphoreSlim has no unmanaged resources
+            // unless AvailableWaitHandle is accessed (which we never do).
+        }
+    }
+
+    public void Dispose()
+    {
+        _timer.Dispose();
+        foreach (var semaphore in _semaphores.Values)
+            semaphore.Dispose();
+        _semaphores.Clear();
+    }
+}

--- a/src/CocApi.Cache/Services/ActiveWarService.cs
+++ b/src/CocApi.Cache/Services/ActiveWarService.cs
@@ -93,7 +93,7 @@ public sealed class ActiveWarService : ServiceBase
         {
             foreach (CachedClan cachedClan in cachedClans)
             {
-                if (!Synchronizer.UpdatingClan.TryAdd(cachedClan.Tag, cachedClan))
+                if (!Synchronizer.ClanLock.TryAcquire(cachedClan.Tag))
                     continue;
 
                 updatingTags.Add(cachedClan.Tag);
@@ -108,7 +108,7 @@ public sealed class ActiveWarService : ServiceBase
         finally
         {
             foreach (string tag in updatingTags)
-                Synchronizer.UpdatingClan.TryRemove(tag, out _);
+                Synchronizer.ClanLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/ClanService.cs
+++ b/src/CocApi.Cache/Services/ClanService.cs
@@ -87,7 +87,7 @@ public sealed class ClanService : ServiceBase
         {
             foreach (CachedClan cachedClan in cachedClans)
             {
-                if (!Synchronizer.UpdatingClan.TryAdd(cachedClan.Tag, cachedClan))
+                if (!Synchronizer.ClanLock.TryAcquire(cachedClan.Tag))
                     continue;
 
                 updatingTags.Add(cachedClan.Tag);
@@ -109,7 +109,7 @@ public sealed class ClanService : ServiceBase
         finally
         {
             foreach (string tag in updatingTags)
-                Synchronizer.UpdatingClan.TryRemove(tag, out _);
+                Synchronizer.ClanLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/ClanWarService.cs
+++ b/src/CocApi.Cache/Services/ClanWarService.cs
@@ -77,7 +77,7 @@ public sealed class ClanWarService : ServiceBase
         {
             foreach (CachedClan cachedClan in cachedClans)
             {
-                if (!Synchronizer.UpdatingClan.TryAdd(cachedClan.Tag, cachedClan))
+                if (!Synchronizer.ClanLock.TryAcquire(cachedClan.Tag))
                     continue;
 
                 updatingTags.Add(cachedClan.Tag);
@@ -99,7 +99,7 @@ public sealed class ClanWarService : ServiceBase
         finally
         {
             foreach (string tag in updatingTags)
-                Synchronizer.UpdatingClan.TryRemove(tag, out _);
+                Synchronizer.ClanLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/CwlWarService.cs
+++ b/src/CocApi.Cache/Services/CwlWarService.cs
@@ -84,7 +84,7 @@ public sealed class CwlWarService : ServiceBase
 
             foreach (CachedWar cachedWar in cachedWars)
             {
-                if (Synchronizer.UpdatingCwlWar.TryAdd(cachedWar.WarTag, cachedWar.Content))
+                if (Synchronizer.CwlWarLock.TryAcquire(cachedWar.WarTag))
                 {
                     updatingCwlWar.Add(cachedWar.WarTag);
 
@@ -101,7 +101,7 @@ public sealed class CwlWarService : ServiceBase
         finally
         {
             foreach (string tag in updatingCwlWar)
-                Synchronizer.UpdatingCwlWar.TryRemove(tag, out _);
+                Synchronizer.CwlWarLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/MemberService.cs
+++ b/src/CocApi.Cache/Services/MemberService.cs
@@ -63,7 +63,7 @@ public sealed class MemberService : ServiceBase
         HashSet<string> updatingTags = new();
 
         foreach (var member in cachedClan.Content.Members)
-            if (Synchronizer.UpdatingVillage.TryAdd(member.Tag, null))
+            if (Synchronizer.VillageLock.TryAcquire(member.Tag))
                 updatingTags.Add(member.Tag);
 
         try
@@ -103,7 +103,7 @@ public sealed class MemberService : ServiceBase
         finally
         {
             foreach (string tag in updatingTags)
-                Synchronizer.UpdatingVillage.TryRemove(tag, out _);
+                Synchronizer.VillageLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/NewCwlWarService.cs
+++ b/src/CocApi.Cache/Services/NewCwlWarService.cs
@@ -92,7 +92,7 @@ public sealed class NewCwlWarService : ServiceBase
         {
             foreach (CachedClan cachedClan in cachedClans.Where(c => c.Group.Content != null)) // content will be null if the RawContent contains notInWar
             {
-                if (!Synchronizer.UpdatingClan.TryAdd(cachedClan.Tag, cachedClan))
+                if (!Synchronizer.ClanLock.TryAcquire(cachedClan.Tag))
                     continue;
 
                 updatingTags.Add(cachedClan.Tag);
@@ -161,7 +161,7 @@ public sealed class NewCwlWarService : ServiceBase
         finally
         {
             foreach (string tag in updatingTags)
-                Synchronizer.UpdatingClan.TryRemove(tag, out _);
+                Synchronizer.ClanLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/NewWarService.cs
+++ b/src/CocApi.Cache/Services/NewWarService.cs
@@ -63,14 +63,14 @@ public sealed class NewWarService : ServiceBase
         HashSet<string> updatingClans = new();
 
         foreach (CachedClan cachedClan in cachedClans)
-            if (Synchronizer.UpdatingClan.TryAdd(cachedClan.Tag, cachedClan))
+            if (Synchronizer.ClanLock.TryAcquire(cachedClan.Tag))
             {
                 updatingClans.Add(cachedClan.Tag);
 
-                if (!Synchronizer.UpdatingWar.TryAdd(cachedClan.CurrentWar.Key, null))
+                if (!Synchronizer.WarLock.TryAcquire(cachedClan.CurrentWar.Key))
                 {
                     updatingClans.Remove(cachedClan.Tag);
-                    Synchronizer.UpdatingClan.TryRemove(cachedClan.Tag, out _);
+                    Synchronizer.ClanLock.Release(cachedClan.Tag);
                 }
             }
 
@@ -130,8 +130,8 @@ public sealed class NewWarService : ServiceBase
         {
             foreach (string tag in updatingClans)
             {
-                Synchronizer.UpdatingClan.TryRemove(tag, out _);
-                Synchronizer.UpdatingWar.TryRemove(cachedClans.Single(c => c.Tag == tag).CurrentWar.Key, out _);
+                Synchronizer.ClanLock.Release(tag);
+                Synchronizer.WarLock.Release(cachedClans.Single(c => c.Tag == tag).CurrentWar.Key);
             }
         }
     }

--- a/src/CocApi.Cache/Services/PlayerService.cs
+++ b/src/CocApi.Cache/Services/PlayerService.cs
@@ -77,7 +77,7 @@ public sealed class PlayerService : ServiceBase
         {
             foreach (CachedPlayer trackedPlayer in trackedPlayers)
             {
-                if (!Synchronizer.UpdatingVillage.TryAdd(trackedPlayer.Tag, trackedPlayer))
+                if (!Synchronizer.VillageLock.TryAcquire(trackedPlayer.Tag))
                     continue;
 
                 updatingTags.Add(trackedPlayer.Tag);
@@ -93,7 +93,7 @@ public sealed class PlayerService : ServiceBase
         finally
         {
             foreach (string tag in updatingTags)
-                Synchronizer.UpdatingVillage.TryRemove(tag, out _);
+                Synchronizer.VillageLock.Release(tag);
         }
     }
 

--- a/src/CocApi.Cache/Services/WarService.cs
+++ b/src/CocApi.Cache/Services/WarService.cs
@@ -30,7 +30,6 @@ public sealed class WarService : ServiceBase
     internal TimeToLiveProvider TimeToLiveProvider { get; }
     public IOptions<CacheOptions> Options { get; }
 
-    private readonly HashSet<string> _unmonitoredClans = new();
     private readonly SemaphoreSlim _semaphore = new(1, 1);
 
 
@@ -93,7 +92,7 @@ public sealed class WarService : ServiceBase
 
         List<Task> tasks = new();
 
-        HashSet<string> updatingWar = new();
+        HashSet<string> acquiredWars = new();
 
         IClansApi clansApi = ApiFactory.Create<IClansApi>();
 
@@ -101,9 +100,12 @@ public sealed class WarService : ServiceBase
         {
             foreach (CachedWar cachedWar in cachedWars)
             {
-                List<CachedClan> cachedClans = allCachedClans.Where(c => c.Tag == cachedWar.ClanTag || c.Tag == cachedWar.OpponentTag).ToList();
+                if (!Synchronizer.WarLock.TryAcquire(cachedWar.Key))
+                    continue;
 
-                updatingWar.Add(cachedWar.Key);
+                acquiredWars.Add(cachedWar.Key);
+
+                List<CachedClan> cachedClans = allCachedClans.Where(c => c.Tag == cachedWar.ClanTag || c.Tag == cachedWar.OpponentTag).ToList();
 
                 tasks.Add(
                     UpdateWarAsync(
@@ -123,11 +125,8 @@ public sealed class WarService : ServiceBase
         }
         finally
         {
-            foreach (string tag in updatingWar)
-                Synchronizer.UpdatingWar.TryRemove(tag, out _);
-
-            foreach (string tag in _unmonitoredClans)
-                Synchronizer.UpdatingClan.TryRemove(tag, out _);
+            foreach (string key in acquiredWars)
+                Synchronizer.WarLock.Release(key);
         }
     }
 
@@ -196,13 +195,11 @@ public sealed class WarService : ServiceBase
 
     private async Task<CachedClan?> CreateCachedClan(IClansApi clansApi, string tag, CacheDbContext dbContext, CancellationToken cancellationToken)
     {
-        if (!Synchronizer.UpdatingClan.TryAdd(tag, null))
+        if (!Synchronizer.ClanLock.TryAcquire(tag))
             return null;
 
         try
         {
-            _unmonitoredClans.Add(tag);
-
             CachedClanWar cachedClanWar = await CachedClanWar
                 .FromCurrentWarResponseAsync(tag, Options.Value.RealTime == null ? default : new(Options.Value.RealTime.Value), TimeToLiveProvider, clansApi, cancellationToken)
                 .ConfigureAwait(false);
@@ -231,7 +228,7 @@ public sealed class WarService : ServiceBase
         }
         finally
         {
-            Synchronizer.UpdatingClan.TryRemove(tag, out _);
+            Synchronizer.ClanLock.Release(tag);
         }
     }
 


### PR DESCRIPTION
# Refactor `Synchronizer` to use `SemaphoreSlim`-backed `TagLock`

## Summary

Replaces the four ad-hoc `ConcurrentDictionary` mutex fields on `Synchronizer` (`UpdatingClan`, `UpdatingVillage`, `UpdatingWar`, `UpdatingCwlWar`) with a unified `TagLock` type backed by `ConcurrentDictionary<string, SemaphoreSlim>`.

## Motivation

`ClansClient.DeleteAsync` and `PlayersClient.DeleteAsync` used a spin-loop to wait for a concurrent service operation to finish on the same tag:

```csharp
while (!Synchronizer.UpdatingClan.TryAdd(tag, null))
    await Task.Delay(250);
```

Under load, this continuously re-queues continuations on the thread pool every 250ms — a thread pool starvation pattern. The fix replaces this with `SemaphoreSlim.WaitAsync`, which parks the caller with no thread pool cost until the lock is free.

## Changes

- **`TagLock.cs`** (new) — `internal sealed class` with `TryAcquire` (non-blocking skip), `AcquireAsync` (async wait), and `Release`. Includes a periodic cleanup timer that evicts idle semaphores using a compare-and-remove to avoid races between cleanup and active callers.
- **`Synchronizer`** — replaces the four `ConcurrentDictionary` fields with `ClanLock`, `VillageLock`, `WarLock`, and `CwlWarLock` `TagLock` instances. Implements `IDisposable` to stop cleanup timers on shutdown.
- **`ClansClient`, `PlayersClient`** — spin-loops replaced with `await lock.AcquireAsync()`.
- **`ClanService`, `ActiveWarService`, `ClanWarService`, `NewCwlWarService`, `NewWarService`, `PlayerService`, `MemberService`, `CwlWarService`** — `TryAdd`/`TryRemove` calls replaced with `TryAcquire`/`Release`.
- **`WarService`** — fixed a pre-existing bug where `WarService.ExecuteScheduledTaskAsync` never acquired `WarLock` before scheduling war updates, allowing concurrent runs to process the same war simultaneously. Also removed the dead `_unmonitoredClans` field (was written but never read).

## Version

`2.14.4` → `2.14.5`
